### PR TITLE
ESU-1232: Add reindex task

### DIFF
--- a/config/environments/pre_production.rb
+++ b/config/environments/pre_production.rb
@@ -39,6 +39,10 @@ EjournalLocator::Application.configure do
   # Use a different logger for distributed setups
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
+  
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,10 @@ EjournalLocator::Application.configure do
 
   # Use a different logger for distributed setups
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,7 @@ services:
   rails:
     environment:
       RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "true"
     volumes:
       - static-content:/project_root/public/assets
   nginx:

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,6 +40,5 @@ docker-compose exec rails bundle exec rake journals:import
 This will import the current daily data from SFX into the running rails container.
 
 ```sh
-docker-compose exec rails curl https://findtext.library.nd.edu/ndu_local/cgi/public/get_file.cgi?file=EJournal_Locator_Daily.xml -o import/ejl-full-e-collection-ALL.xml-marc
-docker-compose exec rails bundle exec rake journals:import
+docker-compose exec rails /project_root/docker/rails_import.sh
 ```

--- a/docker/rails_cleanup.sh
+++ b/docker/rails_cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+bash docker/wait-for-it.sh -t 120 ${DB_HOST}:3306
+bundle exec rails runner -e production 'User.destroy_temporary_users()'
+RAILS_ENV=production bundle exec rake blacklight:delete_old_searches[7] --silent

--- a/docker/rails_entry.sh
+++ b/docker/rails_entry.sh
@@ -1,4 +1,7 @@
+#!/bin/bash
+#
 # All the things that will execute when starting the rails service
+
 # Copy the generated lock file back into the project root. This is to sync this change back to the
 # application after the container has mounted the sync volume
 cp /bundle/Gemfile.lock ./
@@ -9,5 +12,9 @@ sed -i "s;\${SOLR_URL};$SOLR_URL;g" /project_root/config/solr.yml
 
 bash docker/wait-for-it.sh -t 120 ${DB_HOST}:3306
 bash docker/wait-for-it.sh -t 120 ${SOLR_HOST}:8983
+
+# In production we'll be using a persistant database, but not a solr instance,
+# so reindex everything on start
+bundle exec rake journals:index
 
 exec bundle exec rails s

--- a/docker/rails_import.sh
+++ b/docker/rails_import.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+bash docker/wait-for-it.sh -t 120 ${DB_HOST}:3306
+timestamp="$(date +%s)"
+curl -s -w "%{http_code}\\n" https://findtext.library.nd.edu/ndu_local/cgi/public/get_file.cgi?file=EJournal_Locator_Daily.xml -o import/ejl-full-e-collection-ALL.$timestamp.xml-marc
+head -n1 import/ejl-full-e-collection-ALL.$timestamp.xml-marc
+bundle exec rake journals:import

--- a/lib/tasks/journal_import.rake
+++ b/lib/tasks/journal_import.rake
@@ -4,4 +4,10 @@ namespace :journals do
     Airbrake.configuration.rescue_rake_exceptions = true
     JournalImport.process_imports
   end
+
+  task :index => :environment do
+    puts "#{Time.now.strftime("%F %T")}: Updating Solr"
+    Journal.update_solr
+    puts "#{Time.now.strftime("%F %T")}: Solr Update Complete"
+  end
 end


### PR DESCRIPTION
This adds a rake task that can be used to reindex all content. This will
be used on startup within a docker environment to rebuild the index in the
solr container.

Additionally added scripts to handle the nightly import and data cleanup
tasks that were previously handled by the cron jobs defined in
https://github.com/ndlib/ejournal_locator/blob/master/config/schedule.rb.

Replicated the stdout logging behavior in newer rails versions to better
support running in a docker environment (see https://github.com/rails/rails/pull/23734)