### PR TITLE
Fix robots

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,8 +4,6 @@ services:
     environment:
       RAILS_ENV: production
       RAILS_LOG_TO_STDOUT: "true"
-    volumes:
-      - static-content:/project_root/public/assets
   nginx:
     build:
       cache_from:
@@ -17,7 +15,5 @@ services:
       RAILS_HOST: rails
     ports:
       - "80:80"
-    volumes:
-      - static-content:/project_root/assets
-volumes:
-  static-content:
+    volumes_from:
+      - rails:ro

--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -17,3 +17,4 @@ COPY docker/solr.yml /project_root/config/solr.yml
 COPY docker/jetty.yml /project_root/config/jetty.yml
 
 RUN bundle exec rake assets:precompile
+VOLUME /project_root/public

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,23 +4,21 @@ upstream app_service {
   server ${RAILS_HOST}:3000;
 }
 
-
 server {
   listen 80;
   server_name localhost;
-  root /project_root;
+  root /project_root/public;
 
-  location ~ ^/assets/ {
-    expires 1y;
-    add_header Cache-Control public;
+  try_files $uri @app_service;
 
-    add_header ETag "";
-  }
-
-  location / {
+  location @app_service {
       proxy_pass http://app_service;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
   }
+
+  error_page 500 502 503 504 /500.html;
+  client_max_body_size 4G;
+  keepalive_timeout 10;
 }


### PR DESCRIPTION
Production service is currently not properly serving out the robots.txt,
causing increased traffic to the site. This changes the nginx container
to properly serve out all static assets starting at the /public directory.
The previous config only served out /public/assets. It also changes the
mounting of the directory to use the volumes straight from the rails
container. The previous method involved a little too much magic with
mounting to an external fs and it was causing complications with changing
it to public.